### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # bitmex-adaptive-limit
 ## Purpose
-Allows making a market maker limit order that would automatically up your bids or decrease your asks to guarantee fast rebateable orders.
+Allows making a market maker limit order that would automatically up your bids or decrease your asks to guarantee fast rebatable orders.
 ## Installation & setup
 1. `npm install -g bitmex-adaptive-limit`
 2. Setup `BITMEX_API_KEY_ID` and `BITMEX_API_KEY_SECRET` env variables to bitmex api key and secret.


### PR DESCRIPTION
## Summary
- correct spelling of `rebatable` in README line 3

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402dfc41008320b54f8bdfdfa7a5b7