### PR TITLE
Update BitMEX authorization comment

### DIFF
--- a/lib/BitMEXApiKeyAuthorization.js
+++ b/lib/BitMEXApiKeyAuthorization.js
@@ -15,7 +15,7 @@ class BitMEXAPIKeyAuthorization {
   }
 
   apply(obj) {
-    const nonce = Date.now() * 1000 + (nonceCounter++ % 1000); // prevents colliding nonces. Otherwise, use expires
+    const nonce = Date.now() * 1000 + (nonceCounter++ % 1000); // Prevents colliding nonces; alternatively set the 'api-expires' header.
     const expires = (Date.now() / 1000) + 60; // 60s till expiration
     const parsedURL = url.parse(obj.url);
     const thisPath = parsedURL.pathname + (parsedURL.search || '');


### PR DESCRIPTION
## Summary
- clarify the nonce handling comment in `BitMEXApiKeyAuthorization`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68402e06bc788320a786f888aaeb7f84